### PR TITLE
Release shouldn't fail if we can't delete the container

### DIFF
--- a/commands/release.js
+++ b/commands/release.js
@@ -125,7 +125,7 @@ function release(context) {
         }).trim();
         child.execSync(`docker wait ${containerId}`);
         child.execSync(`docker cp ${containerId}:/tmp/slug.tgz ${slugPath}`);
-        child.execSync(`docker rm -f ${containerId}`);
+        child.execSync(`docker rm -f ${containerId} || :`);
         resolve({
           path: path.join(slugPath, 'slug.tgz'),
           name: imageName


### PR DESCRIPTION
There's a known issue on CircleCI where `docker rm` doesn't work. The user they set you up with doesn't have permissions for it. It's sort of by design, as the entire VM gets destroyed at the end anyway.  CircleCI docker based build logs are filled with:

```
Error removing intermediate container 86fdf1139207: Cannot destroy container 86fdf113920797059e66b58c7e195b77e981185cafd9488d2e4d1c2865db75a4: Driver btrfs failed to remove root filesystem 86fdf113920797059e66b58c7e195b77e981185cafd9488d2e4d1c2865db75a4: Failed to destroy btrfs snapshot: operation not permitted
```

When `heroku docker:release` tries to delete a container in this scenario, the entire deploy is aborted. It'd be better if we continued with the process here. Failing to remove the image shouldn't be a cause to abandon the deploy (though it will still be logged).