### PR TITLE
Don't require app.json or docker-compose for release

### DIFF
--- a/commands/release.js
+++ b/commands/release.js
@@ -110,7 +110,16 @@ function release(context) {
     return new Promise(function(resolve, reject) {
       var slugPath = os.tmpdir();
       var output = '';
-      var build = child.spawn('docker-compose', ['build', 'web']);
+
+      if (fs.existsSync("docker-compose.yml")) {
+        var cmd = 'docker-compose';
+        var args = ['build', 'web'];
+      } else {
+        var cmd = 'docker';
+        var args = ['build', '--tag', context.app, '.'];
+      }
+
+      var build = child.spawn(cmd, args);
 
       build.stdout.pipe(process.stdout);
       build.stderr.pipe(process.stderr);
@@ -123,7 +132,7 @@ function release(context) {
 
       function onBuildExit(code) {
         if (code !== 0) {
-          cli.log('Build failed. Make sure `docker-compose build web` returns a 0 exit status.');
+          cli.log('Build failed. Make sure `' + cmd + ' ' + args.join(' ') + '` returns a 0 exit status.');
           process.exit(1);
         }
 

--- a/lib/directory.js
+++ b/lib/directory.js
@@ -17,6 +17,12 @@ function readProcfile(cwd) {
 }
 
 function determineMountDir(dir) {
-  var appJSON = JSON.parse(fs.readFileSync(path.join(dir, 'app.json'), { encoding: 'utf8' }));
+  var appJSONLocation = path.join(dir, 'app.json');
+  var appJSON = {};
+
+  if (fs.existsSync(appJSONLocation)) {
+    var appJSON = JSON.parse(fs.readFileSync(appJSONLocation));
+  }
+
   return path.join('/app/user', appJSON.mount_dir || '');
 }


### PR DESCRIPTION
I don't use docker-compose or app.json for most of my Heroku apps. In such
cases, I would still like to use heroku docker:release. This is a PoC for
making those files no longer required.

- Without app.json, add-on comparison is skipped
- Without docker-compose.yml, `docker build --tag <app> .` is used

Would close #143 and #144.

If you're interested in such a use case, please let me know what it would take
to get this merge-able (there's likely a cleaner way).

Thanks