### PR TITLE
Fix for 2 vulnerable dependency paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "mkdirp": "^0.5.0",
     "node-uuid": "^1.4.3",
     "progress": "1.1.8",
-    "request": "2.53.0",
+    "request": "2.74.0",
     "superagent": "^0.21.0",
     "yamljs": "0.2.4"
   },


### PR DESCRIPTION
heroku-container-tools currently has a 2 vulnerable dependency, introducing 3 different types of known vulnerabilities.

This PR fixes two vulnerable dependency, introducing [remote memory exposure ](https://snyk.io/vuln/npm:request:20160119) vulnerability in the `request` dependency and [ReDos vulnerability](https://snyk.io/vuln/npm:hawk:20160119) in the `hawk` dependency. 

You can see [Snyk test report](https://snyk.io/test/github/heroku/heroku-container-tools) of this project for details. 

This PR changes `Package.json` to upgrade `request` to the newer 2.74.0 version, and will fix  the vulnerability listed above.
You can get alerts and fix PRs for future vulnerabilities for free by [watching this repo with Snyk](https://snyk.io/add).

Note this PR fixes all the vulnerabilities introduced trough `request` dependency, in order to be vulnerability free you will need to upgrade ` yamljs` dependency as well.

Stay Secure,
The Snyk Community